### PR TITLE
encode() data sent to write()

### DIFF
--- a/notepad.py
+++ b/notepad.py
@@ -78,7 +78,7 @@ class Notepad(plugins.PluginInterface):
                     if self.config["dump"]:
                         filename = f"pid.{proc_id}.notepad.dmp"
                         with open(filename, "wb") as f:
-                            f.write(final_data_collection)
+                            f.write(final_data_collection.encode())
                     yield (0, [task_pid, taskname , final_data_collection])
                 except exceptions.InvalidAddressException:
                     continue


### PR DESCRIPTION
`write()` for files opened in binary mode excepts bytes-like data, not a string